### PR TITLE
Add IR50 model from ZhaoJ9014/face.evoLVe.PyTorch

### DIFF
--- a/models/verifier/face_evoLVe_ir50/ir50.py
+++ b/models/verifier/face_evoLVe_ir50/ir50.py
@@ -1,0 +1,67 @@
+from keras.layers import *
+from keras.models import Model
+
+
+def prelu_channelwise(x, name=None):
+    return PReLU(shared_axes=[1,2], name=name)(x)
+
+def bottleneck_IR(x, in_channel, depth, stride=1, prefix=None):
+    if in_channel == depth:
+        shortcut = MaxPooling2D((1, 1), stride)(x)
+    else:
+        shortcut = Conv2D(depth, 1, strides=stride, use_bias=False, name=prefix+".shortcut_layer.0")(x)
+        shortcut = BatchNormalization(epsilon=1e-5, name=prefix+".shortcut_layer.1")(shortcut)
+        
+    x = BatchNormalization(momentum=0.9, epsilon=1e-5, name=prefix+".res_layer.0")(x)
+    x = Conv2D(depth, 3, padding="same", use_bias=False, name=prefix+".res_layer.1")(x)
+    x = prelu_channelwise(x, name=prefix+".res_layer.2")
+    x = ZeroPadding2D(1)(x)
+    x = Conv2D(depth, 3, strides=stride, use_bias=False, name=prefix+".res_layer.3")(x)
+    x = BatchNormalization(momentum=0.9, epsilon=1e-5, name=prefix+".res_layer.4")(x)
+    
+    out = Add()([x, shortcut])
+    return out
+
+def IR50(input_size=(112, 112, 3), weights_path=None, model_name="IR50"):
+    inp = Input(input_size)
+    
+    # input_layer
+    x = Conv2D(64, 3, padding="same", use_bias=False, name="input_layer.0")(inp)
+    x = BatchNormalization(momentum=0.9, epsilon=1e-5, name="input_layer.1")(x)
+    x = prelu_channelwise(x, name="input_layer.2")
+    
+    # body
+    # IR_50: [3, 4, 14, 3]; IR_101: [3, 13, 30, 3]; IR_152: [3, 8, 36, 3]
+    # blocks 0
+    x = bottleneck_IR(x, 64, 64, 2, prefix=f"body.0")
+    for i in range(1, 3):
+        x = bottleneck_IR(x, 64, 64, prefix=f"body.{str(i)}")
+        
+    #blocks 1
+    x = bottleneck_IR(x, 64, 128, 2, prefix=f"body.3")
+    for i in range(4, 7):
+        x = bottleneck_IR(x, 128, 128, prefix=f"body.{str(i)}")
+        
+    # blocks 2
+    x = bottleneck_IR(x, 128, 256, 2, prefix=f"body.7")
+    for i in range(8, 21):
+        x = bottleneck_IR(x, 256, 256, prefix=f"body.{str(i)}")
+        
+    # blocks 2
+    x = bottleneck_IR(x, 256, 512, 2, prefix=f"body.21")
+    for i in range(22, 24):
+        x = bottleneck_IR(x, 512, 512, prefix=f"body.{str(i)}")    
+    
+    # output_layer
+    x = BatchNormalization(momentum=0.9, epsilon=1e-5, name="output_layer.0")(x)
+    x = Dropout(0.5)(x, training=False)
+    x = Permute((3,1,2))(x)
+    x = Flatten()(x)
+    x = Dense(512, name="output_layer.3")(x)
+    out = BatchNormalization(momentum=0.9, epsilon=1e-5, name="output_layer.4")(x)
+    
+    model = Model(inp, out, name=model_name)
+    if weights_path is not None:
+        model.load_weights(weights_path)
+    
+    return model

--- a/models/verifier/face_verifier.py
+++ b/models/verifier/face_verifier.py
@@ -8,20 +8,37 @@ from scipy.spatial import distance
 from pathlib import Path
 
 #from . import umeyama
-from utils.umeyama import umeyama
 
 FILE_PATH = Path(__file__).parent.resolve()
 
+import sys
+sys.path.append(str(FILE_PATH.parent.parent.parent.resolve()))
+from utils.umeyama import umeyama
+
 class FaceVerifier():
+    """
+    This class serves as wrapper for four face verification models
+
+    # Arguments
+        extractor: String, one of featrure extractor network 
+                   "facenet", "insightface", "ir50_asia", and "ir50_ms1m"
+        classes: Ineger whiich should be a fixed value of 512.
+    """
     def __init__(self, extractor="facenet", classes=512):
-        self.extractor_type = extractor
+        self.extractor_type = extractor.lower()
         self.latent_dim = classes
         if extractor == "facenet":
             self.input_resolution = 160
-            self.weights_path = str(FILE_PATH)+"/facenet/facenet_keras_weights_VGGFace2.h5"
+            self.weights_path = FILE_PATH / "facenet" / "facenet_keras_weights_VGGFace2.h5"
         elif extractor == "insightface":
             self.input_resolution = 112
-            self.weights_path = str(FILE_PATH)+"/insightface/lresnet100e_ir_keras.h5"
+            self.weights_path = FILE_PATH / "insightface" / "lresnet100e_ir_keras.h5"
+        elif extractor.lower() == "ir50_asia":
+            self.input_resolution = 112
+            self.weights_path = FILE_PATH / "face_evoLVe_ir50" / "backbone_ir50_asia_keras.h5"
+        elif extractor.lower() == "ir50_ms1m":
+            self.input_resolution = 112
+            self.weights_path = FILE_PATH / "face_evoLVe_ir50" / "backbone_ir50_ms1m_keras.h5"
         else:
             raise ValueError(f"Received an unknown extractor: {str(extractor)}.")
         
@@ -31,30 +48,25 @@ class FaceVerifier():
         self.detector = False
         
     def build_networks(self, classes=512):
+        input_tensor = Input((None, None, 3))
+        resize_layer = self.resize_tensor(size=self.input_resolution)
+        l2_normalize = self.l2_norm()
         if self.extractor_type == "facenet":
-            """
-            InceptionResNetV1 expects inputs that have range [0, 255].
-            """
             from .facenet.inception_resnet_v1 import InceptionResNetV1
-            input_tensor = Input((None, None, 3))
             facenet = InceptionResNetV1(weights_path=self.weights_path, classes=classes)
             facenet = Model(facenet.inputs, facenet.layers[-1].output) # layers[-1] is a BN layers
-            resize_layer = self.resize_tensor(size=self.input_resolution)
             preprocess_layer = self.preprocess()
-            l2_normalize = self.l2_norm()
-            output_tensor = l2_normalize(facenet(preprocess_layer(resize_layer(input_tensor))))       
-            return Model(input_tensor, output_tensor)
+            output_tensor = l2_normalize(facenet(preprocess_layer(resize_layer(input_tensor))))    
         elif self.extractor_type == "insightface":
-            """
-            LResNet100E-IR expects input images that have range [0, 255].
-            """
             from .insightface.lresnet100e_ir import LResNet100E_IR
-            input_tensor = Input((None, None, 3))
             lresnet100e_ir = LResNet100E_IR(weights_path=self.weights_path)
-            resize_layer = self.resize_tensor(size=self.input_resolution)
-            l2_normalize = self.l2_norm()
-            output_tensor = l2_normalize(lresnet100e_ir(resize_layer(input_tensor)))        
-            return Model(input_tensor, output_tensor)
+            output_tensor = l2_normalize(lresnet100e_ir(resize_layer(input_tensor)))  
+        elif self.extractor_type == "ir50_asia" or self.extractor_type == "ir50_ms1m":
+            from .face_evoLVe_ir50.ir50 import IR50
+            ir50 = IR50(weights_path=self.weights_path)
+            preprocess_layer = self.preprocess()
+            output_tensor = l2_normalize(ir50(preprocess_layer(resize_layer(input_tensor))))     
+        return Model(input_tensor, output_tensor)
     
     def set_detector(self, detector):
         self.detector = detector
@@ -74,9 +86,16 @@ class FaceVerifier():
             x = (x - 127.5) / 128
             x = K.map_fn(lambda im: tf.image.per_image_standardization(im), x)
             return x     
+        def preprocess_ir50(x):
+            x = (x - 127.5) / 128
+            x = x[:, 8:120, 8:120, :]
+            return x  
         
-        input_tensor = Input((None, None, 3))      
-        output_tensor = Lambda(preprocess_facenet)(input_tensor)        
+        input_tensor = Input((None, None, 3)) 
+        if self.extractor_type == "facenet":
+            output_tensor = Lambda(preprocess_facenet)(input_tensor)
+        elif self.extractor_type == "ir50_asia" or self.extractor_type == "ir50_ms1m":
+            output_tensor = Lambda(preprocess_ir50)(input_tensor)
         return Model(input_tensor, output_tensor)
     
     def l2_norm(self):            
@@ -84,13 +103,30 @@ class FaceVerifier():
         output_tensor = Lambda(lambda x: K.l2_normalize(x))(input_tensor)
         return Model(input_tensor, output_tensor)
     
-    def verify(self, im1, im2, threshold=0.5, with_detection=False, return_distance=True):
-        emb1 = self.extract_embeddings(im1, with_detection=with_detection)
-        emb2 = self.extract_embeddings(im2, with_detection=with_detection)
+    def verify(self, im1, im2, threshold=0.5, with_detection=False, with_alignment=False, return_distance=True):
+        """Verify two given images by computing the distance between their latent embeddings.
+
+        Since insightface and IR50 models were trained using ArcFace as its objective,
+        we introduce a hybrid distance for verification using these models.
+
+        # Arguments
+            im1: Numpy array, the first RGB input image.
+            im2: Numpy array, the second RGB input image.
+            threshold: Floating point between zero and one, threshold for similarity.
+            with_detection: Boolean, whether to apply face detection before verification.
+            with_alignment: Boolean, whether to apply face alignment before feature extraction.
+            return_distance: Boolean, whether to return similarity distance of the two input images.
+
+        # Returns
+            is_same_person: Boolean, whether the two input images belong to the same identity.
+            dist: Floating point, similarity distance of the two input images.
+        """
+        emb1 = self.extract_embeddings(im1, with_detection=with_detection, with_alignment=with_alignment)
+        emb2 = self.extract_embeddings(im2, with_detection=with_detection, with_alignment=with_alignment)
         
         if self.extractor_type == "facenet":
             dist = self.compute_cosine_distance(emb1, emb2)
-        elif self.extractor_type == "insightface":
+        elif self.extractor_type == "insightface" or self.extractor_type == "ir50_asia" or self.extractor_type == "ir50_ms1m":
             euclidean_dist = np.sum(np.square(emb1 - emb2))
             cosine_dist = 1 - np.dot(emb1, emb2.T)
             dist = (euclidean_dist + cosine_dist) / 3.75 # 3.75 here is purely heuristic so that it works fine with default threshold=0.5.
@@ -101,29 +137,41 @@ class FaceVerifier():
         else:
             return is_same_person
     
-    def extract_embeddings(self, im, with_detection=False, return_face=False):
+    def extract_embeddings(self, im, with_detection=False, with_alignment=False, return_face=False):
+        """Extract latent embeddings of the input image
+
+        # Arguments
+            im: Numpy array, the input image.
+            with_detection: Boolean, whether to apply face detetion before feature extraction.
+            with_alignment: Boolean, whether to apply face alignment before feature extraction.
+            return_face: Boolean, whether to return the preprocessed face (input of feature extractor).
+
+        # Returns
+            embeddings: Numpy array, latent embeddings of input image.
+            face: Numpy array, preprocessed face as the input of feature extractor.
+        """
         if with_detection:
             try:
-                if self.extractor_type == "facenet":
-                    faces = self.detector.detect_face(im, with_landmarks=False)
-                elif self.extractor_type == "insightface":
+                if with_alignment:
                     faces, landmarks = self.detector.detect_face(im, with_landmarks=True)
                     landmarks = [self.detector.convert_landmarks_68_to_5(l) for l in landmarks]
+                else:
+                    faces = self.detector.detect_face(im, with_landmarks=False)
             except:
                 raise NameError("Error occured duaring face detection. \
-                Please check if face detector has been set through set_detector().")
+                Please check if face detector has been set through set_detector() and there are available GPUs.")
             if len(faces) > 1:
                 print("Multiple faces detected, only the most confident one is used for verification.")
                 most_conf_idx = np.argmax(faces, axis=0)[-1]
                 faces = faces[most_conf_idx:most_conf_idx+1]
-                if self.extractor_type == "insightface":
+                if with_alignment:
                     landmarks = landmarks[most_conf_idx:most_conf_idx+1]
                     
-            if self.extractor_type == "facenet":
-                x0, y0, x1, y1, _ = faces[0].astype(np.int32)
-                face = im[x0:x1, y0:y1]            
-            elif self.extractor_type == "insightface":
+            if with_alignment:        
                 face = self.align_face(im, landmarks[0][..., ::-1], self.input_resolution)
+            else:
+                x0, y0, x1, y1, _ = faces[0].astype(np.int32)
+                face = im[x0:x1, y0:y1]    
         else:
             face = im
         
@@ -144,7 +192,8 @@ class FaceVerifier():
             [48.0252, 71.7366],
             [33.5493, 92.3655],
             [62.7299, 92.2041] ], dtype=np.float32 )
-        dst[:,0] += 8.0        
+        dst[:,0] += 8.0       
+        dst = dst / 112 * size 
         M = umeyama(src, dst, True)[0:2]
         warped = cv2.warpAffine(im, M, (size, size), borderValue=0.0)
         return warped 
@@ -152,4 +201,5 @@ class FaceVerifier():
     @staticmethod
     def compute_cosine_distance(emb1, emb2):
         return distance.cosine(emb1, emb2)
+        
         

--- a/models/verifier/face_verifier.py
+++ b/models/verifier/face_verifier.py
@@ -153,4 +153,3 @@ class FaceVerifier():
     def compute_cosine_distance(emb1, emb2):
         return distance.cosine(emb1, emb2)
         
-        


### PR DESCRIPTION
1. Add an ir50 model, which is compatible with:
   - IR50 trained on MS-Celeb-1M, and
   - IR50 trained on private Asia face dataset from [ZhaoJ9014/face.evoLVe.PyTorch](https://github.com/ZhaoJ9014/face.evoLVe.PyTorch).
2. Update `face_verifier.py`
   - Use pathlib for file paths.